### PR TITLE
🔍 Allow search to filter by category/description

### DIFF
--- a/lua/telescope/_extensions/emoji.lua
+++ b/lua/telescope/_extensions/emoji.lua
@@ -32,7 +32,7 @@ local function search(opts)
       results = emojis,
       entry_maker = function(emoji)
         return {
-          ordinal = emoji.name,
+          ordinal = emoji.name .. emoji.category .. emoji.description,
           display = make_display,
 
           name = emoji.name,


### PR DESCRIPTION
SUPER JANK!

Allows you to filter based on category and description though, which makes it quite a bit more powerful/useful.

There was an issue opened requesting to filter by category and this essentially allows it to do so with the addition of description which is what I want. However, this is quite janky and can be made better through more configuration options.