### PR TITLE
fix <p> fail to paste

### DIFF
--- a/lua/telescope/_extensions/emoji.lua
+++ b/lua/telescope/_extensions/emoji.lua
@@ -9,6 +9,7 @@ local emojis = require("telescope-emoji").emojis
 
 local function action(emoji)
   vim.fn.setreg("*", emoji.value)
+  vim.fn.setreg('"', emoji.value)
   print([[Press p or "*p to paste this emoji]] .. emoji.value)
 end
 


### PR DESCRIPTION
If not set register `"`,  I fail to just press `p` to paste the selected emoji.
Maybe the nvim version problem? 
I use `nvim 0.8.1`. Anyway, set  register `"` explicitly works fine.

```
NVIM v0.8.1
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
```